### PR TITLE
fix(ci): update DDL configuration and enforce user_id constraint

### DIFF
--- a/src/main/java/dev/guilhermeluan/ongoing/subscriptions/entities/Subscriptions.java
+++ b/src/main/java/dev/guilhermeluan/ongoing/subscriptions/entities/Subscriptions.java
@@ -69,6 +69,6 @@ public class Subscriptions {
     private SubscriptionType subscriptionType;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -5,7 +5,7 @@ spring:
     password: local_password
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -5,7 +5,7 @@ spring:
     name: ongoing
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   flyway:
     enabled: true
 


### PR DESCRIPTION
* Change ddl-auto setting from 'update' to 'validate' in application configurations.
* Ensure 'user_id' column in Subscriptions is non-nullable.