### PR TITLE
feat: remove mocked sidebar menus (categories, calendar, settings)

### DIFF
--- a/docs/plans/2026-02-25-cache-subscriptions-dashboard-design.md
+++ b/docs/plans/2026-02-25-cache-subscriptions-dashboard-design.md
@@ -1,0 +1,102 @@
+# Cache Strategy: Subscriptions + Dashboard (Hybrid)
+
+## Context
+
+Today, `subscriptions` and `dashboard` are fetched directly on each request. The backend already has Redis and Spring Cache enabled, but caching is currently focused on exchange rates. On the frontend, hooks fetch on mount/refetch without a dedicated cache layer.
+
+## Decision
+
+Adopt a **hybrid cache strategy**:
+
+1. **Backend cache (Redis)** as the source of truth for shared performance gains.
+2. **Frontend in-memory cache** with short TTL for faster navigation UX.
+
+This balances scalability (server-side) and responsiveness (client-side).
+
+## Scope
+
+- Backend:
+  - `GET /api/v1/subscriptions` (list with filters/pagination)
+  - `GET /api/v1/subscriptions/{id}` (detail)
+  - `GET /api/v1/dashboard`
+- Frontend:
+  - `useSubscriptions`
+  - `useDashboard`
+
+## Backend Plan
+
+### 1) Cache reads with user-scoped keys
+
+- Include `userId` in all keys.
+- For subscriptions list, include relevant query params (`page`, `size`, `sort`, `name`, `active`, `categoryId`).
+
+Suggested cache names:
+- `subscriptions-list`
+- `subscriptions-by-id`
+- `dashboard`
+
+### 2) TTL policy (initial)
+
+- `dashboard`: 30-60 seconds
+- `subscriptions-list`: 1-3 minutes
+- `subscriptions-by-id`: 1-3 minutes
+
+Use short TTLs first, then tune with usage telemetry.
+
+### 3) Invalidation policy
+
+On create/update/delete subscription:
+- Evict `subscriptions-list` for the user
+- Evict `subscriptions-by-id` for the affected id/user
+- Evict `dashboard` for the user
+
+Invalidation must happen in mutation flow to avoid stale totals.
+
+## Frontend Plan
+
+### 1) Memory cache in hooks
+
+- Add lightweight cache map with timestamp + data.
+- Cache key by query params for subscriptions and fixed key per user/session for dashboard.
+
+### 2) Freshness model
+
+- Return cached data immediately when valid.
+- Trigger background refresh (stale-while-revalidate) where appropriate.
+- Keep TTL short to reduce staleness risk.
+
+### 3) Frontend invalidation
+
+After create/update/delete subscription:
+- Invalidate subscriptions cache entries
+- Invalidate dashboard cache entry
+- Refetch visible data
+
+On logout:
+- Clear auth and cache memory.
+
+## Rollout Phases
+
+1. Backend read caching.
+2. Backend invalidation on mutations.
+3. Frontend cache layer in hooks.
+4. Frontend invalidation + refetch integration.
+5. Tests and monitoring.
+
+## Validation
+
+- Backend tests:
+  - cache hit/miss behavior
+  - user isolation in keys
+  - mutation invalidation correctness
+- Frontend tests:
+  - TTL expiration behavior
+  - stale-while-revalidate behavior
+  - invalidation after mutation/logout
+
+## Risks and Mitigations
+
+- **Stale data**: keep short TTL + strict invalidation.
+- **Cross-user leakage**: enforce `userId` in all keys.
+- **Key explosion**: limit cached dimensions to effective query params only.
+

--- a/frontend/src/components/app/Sidebar.tsx
+++ b/frontend/src/components/app/Sidebar.tsx
@@ -34,54 +34,6 @@ const navigation = [
       </svg>
     ),
   },
-  {
-    name: "Categorias",
-    href: "/categories",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: "Calendário",
-    href: "/calendar",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-        />
-      </svg>
-    ),
-  },
-  {
-    name: "Configurações",
-    href: "/settings",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-        />
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-        />
-      </svg>
-    ),
-  },
 ];
 
 interface SidebarProps {


### PR DESCRIPTION
## O que muda

Remove os itens de menu mockados do sidebar da área autenticada:
- ~~Categorias~~ → `/categories`
- ~~Calendário~~ → `/calendar`
- ~~Configurações~~ → `/settings`

O sidebar agora exibe apenas os itens com funcionalidade implementada: **Dashboard** e **Assinaturas**.